### PR TITLE
Fix: Implement audio message sending, storage, and deletion

### DIFF
--- a/lib/app/modules/chat/controllers/chat_controller.dart
+++ b/lib/app/modules/chat/controllers/chat_controller.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:uuid/uuid.dart';
 import 'package:yapster/app/core/utils/supabase_service.dart';
 import 'package:yapster/app/modules/chat/modles/message_model.dart';
 import 'chat_controller_messages.dart';
@@ -74,7 +77,168 @@ class ChatController extends GetxController
     messagesToAnimate.remove(messageId);
   }
 
-  Future<void> uploadAndSendAudio(String chatId, String audioPath) async {
-    // in a bitttt
+  Future<void> uploadAndSendAudio(String chatId, String audioPath, {Duration? duration}) async {
+    isSendingMessage.value = true;
+    try {
+      final messageId = Uuid().v4();
+      final senderId = _supabaseService.client.auth.currentUser?.id;
+
+      if (senderId == null) {
+        Get.snackbar('Error', 'User not logged in.');
+        print('Error: User not logged in.');
+        return;
+      }
+
+      // Optimistic UI Update (Part 1)
+      final tempMessage = MessageModel(
+        messageId: messageId,
+        chatId: chatId,
+        senderId: senderId,
+        content: audioPath, // Local path for now
+        messageType: 'audio',
+        recipientId: '', // Placeholder - adjust as needed
+        expiresAt: DateTime.now().add(Duration(days: 7)), // Placeholder
+        createdAt: DateTime.now(),
+        isRead: false,
+        duration: duration, // Pass duration to the temporary optimistic message
+      );
+
+      messages.insert(0, tempMessage);
+      messagesToAnimate.add(messageId);
+
+      // Upload to Supabase Storage
+      final filePathInStorage = '$senderId/$chatId/$messageId.m4a';
+      String audioUrl;
+
+      try {
+        await _supabaseService.client.storage
+            .from('audio_messages') // Bucket name
+            .upload(filePathInStorage, File(audioPath));
+
+        audioUrl = _supabaseService.client.storage
+            .from('audio_messages')
+            .getPublicUrl(filePathInStorage);
+      } catch (e) {
+        // Handle upload error
+        messages.removeWhere((m) => m.messageId == messageId);
+        messagesToAnimate.remove(messageId);
+        Get.snackbar('Error', 'Failed to upload audio: ${e.toString()}');
+        print('Error uploading audio: $e');
+        return; // Do not proceed if upload fails
+      }
+
+      // Save Message to Supabase Database
+      final messageData = {
+        'message_id': messageId,
+        'chat_id': chatId,
+        'sender_id': senderId,
+        'content': audioUrl,
+        'message_type': 'audio',
+        'recipient_id': '', // Adjust as needed
+        'expires_at': DateTime.now().add(Duration(days: 7)).toIso8601String(), // Adjust
+        'created_at': DateTime.now().toIso8601String(),
+        'is_read': false,
+        'duration_seconds': duration?.inSeconds, // Ensure this line is present and uncommented
+      };
+
+      try {
+        await _supabaseService.client.from('messages').insert(messageData);
+
+        // Optimistic UI Update (Part 2) - Update the existing temp message
+        final index = messages.indexWhere((m) => m.messageId == messageId);
+        if (index != -1) {
+          // Create a new MessageModel from the data that was sent to the DB
+          // This ensures the local model matches the remote one
+          // MessageModel.fromJson expects date strings to be in ISO8601 format
+          // and will parse them into DateTime objects.
+          messages[index] = MessageModel.fromJson(messageData);
+        }
+      } catch (e) {
+        // Handle database error
+        messages.removeWhere((m) => m.messageId == messageId);
+        messagesToAnimate.remove(messageId);
+        // Attempt to delete the already uploaded audio from storage to prevent orphans
+        try {
+          await _supabaseService.client.storage.from('audio_messages').remove([filePathInStorage]);
+        } catch (storageError) {
+          print('Error deleting orphaned audio from storage: $storageError');
+          // Optionally, inform the user about the orphaned file or log for manual cleanup
+        }
+        Get.snackbar('Error', 'Failed to send message: ${e.toString()}');
+        print('Error saving message to database: $e');
+      }
+    } finally {
+      isSendingMessage.value = false;
+    }
+  }
+
+  String? _extractPathFromUrl(String url) {
+    try {
+      final uri = Uri.parse(url);
+      // Example: /storage/v1/object/public/audio_messages/path/to/file.m4a
+      // We need "path/to/file.m4a"
+      final pathSegments = uri.pathSegments;
+      // Ensure there are enough segments and the bucket name is correct
+      if (pathSegments.length > 5 && pathSegments[4] == 'audio_messages') { 
+        return pathSegments.sublist(5).join('/');
+      }
+      print('Error extracting path: URL structure not as expected. Segments: $pathSegments');
+      return null;
+    } catch (e) {
+      print('Error parsing URL: $e');
+      return null;
+    }
+  }
+
+  Future<void> deleteAudioMessage(String messageId, String audioUrl) async {
+    deletingMessageId.value = messageId;
+    try {
+      // 1. Delete from Supabase Storage
+      final String? filePathInStorage = _extractPathFromUrl(audioUrl);
+
+      if (filePathInStorage == null || filePathInStorage.isEmpty) {
+        Get.snackbar('Error', 'Could not determine file path for deletion. URL: $audioUrl');
+        print('Error: Could not determine file path for deletion from URL: $audioUrl');
+        return; // No need to set deletingMessageId.value = '' here, finally block will do it.
+      }
+
+      try {
+        await _supabaseService.client.storage
+            .from('audio_messages') // Bucket name
+            .remove([filePathInStorage]);
+        print('Successfully deleted $filePathInStorage from storage.');
+      } catch (e) {
+        print('Error deleting audio from storage: $e. Path: $filePathInStorage');
+        Get.snackbar('Error', 'Could not delete audio file from storage. Please try again.');
+        // Stop if storage deletion fails to prevent orphaned DB entries
+        return; // No need to set deletingMessageId.value = '' here, finally block will do it.
+      }
+
+      // 2. Delete from Supabase Database
+      try {
+        await _supabaseService.client
+            .from('messages')
+            .delete()
+            .eq('message_id', messageId);
+        
+        print('Successfully deleted message $messageId from database.');
+        // Assuming real-time listener handles local list removal.
+        // If not, uncomment: messages.removeWhere((m) => m.messageId == messageId);
+
+      } catch (e) {
+        print('Error deleting message $messageId from database: $e');
+        Get.snackbar('Error', 'Could not delete message details. Please try again.');
+        // If DB deletion fails, the storage file is already deleted (orphaned file).
+        // This is not ideal, but the function has attempted its best.
+      }
+
+    } catch (e) {
+      // Catch any other unexpected errors from the try block
+      print('An unexpected error occurred in deleteAudioMessage: $e');
+      Get.snackbar('Error', 'An unexpected error occurred while deleting the message.');
+    }
+    finally {
+      deletingMessageId.value = '';
+    }
   }
 }

--- a/lib/app/modules/chat/modles/message_model.dart
+++ b/lib/app/modules/chat/modles/message_model.dart
@@ -8,6 +8,7 @@ class MessageModel {
   final DateTime expiresAt;
   final bool isRead;
   final DateTime createdAt; // ✅ Add this
+  final Duration? duration; // Add this
 
   MessageModel({
     required this.messageId,
@@ -19,6 +20,7 @@ class MessageModel {
     required this.expiresAt,
     required this.isRead,
     required this.createdAt, // ✅ Add this
+    this.duration, // Add this
   });
 
   factory MessageModel.fromJson(Map<String, dynamic> json) => MessageModel(
@@ -31,5 +33,8 @@ class MessageModel {
     expiresAt: DateTime.parse(json['expires_at']),
     isRead: json['is_read'] ?? false,
     createdAt: DateTime.parse(json['created_at']), // ✅ Add this
+    duration: json['duration_seconds'] != null
+        ? Duration(seconds: json['duration_seconds'] as int)
+        : null, // Add this logic
   );
 }

--- a/lib/app/modules/chat/services/audio_services.dart
+++ b/lib/app/modules/chat/services/audio_services.dart
@@ -22,6 +22,7 @@ class AudioService extends GetxService {
   // For waveform visualization during recording
   RecorderController? recorderController;
   Timer? _waveformTimer;
+  DateTime? _recordingStartTime; // To calculate duration
 
   Future<AudioService> init() async {
     recorder = record_plugin.AudioRecorder();
@@ -103,8 +104,10 @@ class AudioService extends GetxService {
         recorderController?.refresh();
       });
 
+      _recordingStartTime = DateTime.now(); // Start timer
       return filePath;
     } catch (e) {
+      _recordingStartTime = null; // Reset on error
       debugPrint('Error starting recording: $e');
       Get.snackbar('Error', 'Failed to start recording');
       await _disposeCurrentController();
@@ -112,39 +115,58 @@ class AudioService extends GetxService {
     }
   }
 
-  Future<String?> stopRecording() async {
-    if (!isRecording.value) {
-      debugPrint('Not recording');
+  Future<Map<String, dynamic>?> stopRecording() async {
+    // Check if recording and if startTime is available
+    if (!isRecording.value || _recordingStartTime == null) {
+      debugPrint('AudioService: stopRecording called but not recording or startTime is null.');
+      // Ensure state is reset if it's inconsistent
+      if (isRecording.value) {
+        isRecording.value = false;
+        currentRecordingPath.value = '';
+      }
       return null;
     }
 
+    final Duration duration = DateTime.now().difference(_recordingStartTime!);
+
     try {
+      // Stop the waveform refresh timer explicitly. _disposeCurrentController also cancels it,
+      // but doing it here ensures it's stopped before recorder.stop().
       _waveformTimer?.cancel();
-      _waveformTimer = null;
 
-      // Stop waveform recorder
-      await recorderController?.stop();
-      recorderController?.dispose();
-      recorderController = null;
-
-      // Stop audio recorder
-      await recorder.stop();
-      final path = currentRecordingPath.value;
-      isRecording.value = false;
-      currentRecordingPath.value = '';
-
-      if (path.isEmpty || !File(path).existsSync()) {
-        throw Exception('Recording file not found');
+      // Stop the visual waveform recorder.
+      // This should ideally not throw if called multiple times or on an uninitialized controller,
+      // but defensive coding with null check is good.
+      if (recorderController != null && recorderController!.isRecording) {
+         await recorderController?.stop();
       }
 
-      return path;
+      // Stop the main audio recorder. This is what writes the file.
+      final String? path = await recorder.stop();
+      
+      // Path from recorder.stop() is the source of truth.
+      // currentRecordingPath.value was set at start, can be used for reference or cleared.
+
+      if (path == null || path.isEmpty) {
+        throw Exception('Recorder returned null or empty path.');
+      }
+      if (!File(path).existsSync()) {
+        throw Exception('Recorded file not found at path: $path');
+      }
+      
+      // Successfully stopped and file exists.
+      // isRecording and currentRecordingPath will be reset in finally.
+      return {'path': path, 'duration': duration};
     } catch (e) {
       debugPrint('Error stopping recording: $e');
-      Get.snackbar('Error', 'Failed to stop recording');
+      Get.snackbar('Error', 'Failed to stop recording: ${e.toString()}');
       return null;
     } finally {
-      _waveformTimer?.cancel();
-      _waveformTimer = null;
+      // Reset state and dispose resources
+      _recordingStartTime = null;
+      isRecording.value = false; // Ensure recording state is reset
+      currentRecordingPath.value = ''; // Clear the stored path
+      await _disposeCurrentController(); // Clean up waveform controller and its timer
     }
   }
 
@@ -202,9 +224,10 @@ class AudioService extends GetxService {
 
   @override
   void onClose() {
-    _waveformTimer?.cancel();
-    recorderController?.dispose();
-    recorder.dispose();
+    _waveformTimer?.cancel(); // Cancel timer
+    recorderController?.dispose(); // Dispose controller
+    recorder.dispose(); // Dispose main recorder
+    _recordingStartTime = null; // Clear start time
     super.onClose();
   }
 }


### PR DESCRIPTION
This commit introduces the full lifecycle for audio messages:

1.  **Sending:**
    - Audio is recorded, and its duration is captured.
    - `ChatController.uploadAndSendAudio` handles uploading the audio file to Supabase Storage (in the `audio_messages` bucket) and saving message metadata (including audio URL and duration) to the `messages` database table.
    - Optimistic UI updates are implemented, adding the message to the UI immediately and updating it once the upload and database insertion are complete.
    - Send animations are triggered using the existing `messagesToAnimate` mechanism.

2.  **Storage:**
    - `MessageModel` updated to include an optional `duration` field.
    - Database schema is expected to have a `duration_seconds` column for messages.

3.  **Deletion:**
    - `MessageOptions` now correctly identifies audio messages.
    - Calls `ChatController.deleteAudioMessage`, which:
        - Deletes the audio file from Supabase Storage.
        - Deletes the message record from the database.
    - UI animations for deletion are triggered by setting `deletingMessageId`.
    - Deletion for non-audio messages in `MessageOptions` has been clarified to perform a direct database delete, relying on real-time updates for UI changes.

4.  **Duration Handling:**
    - `AudioService` and `AudioRecorder` were updated to capture and pass the recording duration.

This resolves the issue of broken audio message functionality and ensures that send/delete animations are respected throughout the process.